### PR TITLE
Ajout d’un flyer A5 avec fond perdu et mentions légales (recto/verso)

### DIFF
--- a/flyer-a5.html
+++ b/flyer-a5.html
@@ -1,0 +1,416 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>RCP Multiservices — Flyer A5 (avec fond perdu et traits de coupe)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    /* Impression: 2 pages (recto/verso), format A5 avec fond perdu simulé (3 mm) et traits de coupe */
+    @page {
+      size: A5 portrait;
+      margin: 0; /* On gère le fond perdu et la zone de sécurité manuellement */
+    }
+
+    :root{
+      --bleed: 3mm;          /* fond perdu */
+      --safe: 6mm;           /* marge intérieure de sécurité */
+      --paper-w: 148mm;
+      --paper-h: 210mm;
+      --bg: #0f172a;         /* slate-900 */
+      --primary: #22c55e;    /* green-500 */
+      --accent: #14b8a6;     /* teal-500 */
+      --text: #0b1220;       /* near black */
+      --muted: #475569;      /* slate-500 */
+    }
+
+    html, body {
+      background: #888; /* rendu écran */
+      height: 100%;
+    }
+
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+      color: #111827;
+    }
+
+    .page {
+      position: relative;
+      width: calc(var(--paper-w) + var(--bleed) * 2);
+      height: calc(var(--paper-h) + var(--bleed) * 2);
+      margin: 12px auto;
+      background: white;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.15);
+      overflow: hidden;
+      page-break-after: always;
+    }
+
+    /* Zone d'impression (inclut le fond perdu) */
+    .artboard {
+      position: absolute;
+      inset: 0;
+      background: white;
+    }
+
+    /* Zone utile (bord à bord A5 sans fond perdu) */
+    .trim {
+      position: absolute;
+      left: var(--bleed);
+      top: var(--bleed);
+      width: var(--paper-w);
+      height: var(--paper-h);
+      background: white;
+      overflow: hidden;
+    }
+
+    /* Marge de sécurité (éviter texte proche du bord) */
+    .safe {
+      position: absolute;
+      left: calc(var(--bleed) + var(--safe));
+      top: calc(var(--bleed) + var(--safe));
+      right: calc(var(--bleed) + var(--safe));
+      bottom: calc(var(--bleed) + var(--safe));
+    }
+
+    /* Traits de coupe (4 coins) */
+    .crop {
+      position: absolute;
+      pointer-events: none;
+    }
+    /* horizontaux top/bottom */
+    .crop.h {
+      width: 8mm;
+      height: 0;
+      border-top: 0.25pt solid #000;
+    }
+    .crop.v {
+      width: 0;
+      height: 8mm;
+      border-left: 0.25pt solid #000;
+    }
+    .crop.top-left.h    { left: var(--bleed);            top: 0;                    transform: translate(-8mm, 0); }
+    .crop.top-left.v    { left: 0;                       top: var(--bleed);          transform: translate(0, -8mm); }
+    .crop.top-right.h   { right: var(--bleed);           top: 0;                    }
+    .crop.top-right.v   { right: 0;                      top: var(--bleed);          transform: translate(0, -8mm); }
+    .crop.bottom-left.h { left: var(--bleed);            bottom: 0;                 transform: translate(-8mm, 0); }
+    .crop.bottom-left.v { left: 0;                       bottom: var(--bleed);       }
+    .crop.bottom-right.h{ right: var(--bleed);           bottom: 0;                 }
+    .crop.bottom-right.v{ right: 0;                      bottom: var(--bleed);       }
+
+    /* Habillage recto */
+    .hero {
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, var(--bg) 0%, #0b2534 60%, #0a3f39 100%);
+      color: #fff;
+    }
+    .hero .brand {
+      position: absolute;
+      left: calc(var(--safe));
+      top: calc(var(--safe));
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      font-weight: 800;
+      letter-spacing: 0.3px;
+    }
+    .hero .brand .logo {
+      width: 14mm;
+      height: 14mm;
+      border-radius: 4mm;
+      background: radial-gradient(circle at 30% 30%, var(--primary), var(--accent));
+      box-shadow: 0 4px 16px rgba(34,197,94,0.4), inset 0 0 40px rgba(255,255,255,0.15);
+    }
+    .hero .brand .name {
+      font-size: 16pt;
+      line-height: 1;
+    }
+    .hero .headline {
+      position: absolute;
+      left: calc(var(--safe));
+      right: calc(var(--safe));
+      top: 38mm;
+      font-size: 22pt;
+      font-weight: 800;
+      line-height: 1.1;
+      text-wrap: balance;
+    }
+    .hero .sub {
+      position: absolute;
+      left: calc(var(--safe));
+      right: calc(var(--safe));
+      top: 78mm;
+      font-size: 11pt;
+      color: #e2e8f0;
+      line-height: 1.5;
+    }
+    .hero .badges {
+      position: absolute;
+      left: calc(var(--safe));
+      right: calc(var(--safe));
+      top: 112mm;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 6mm 8mm;
+    }
+    .badge {
+      background: rgba(255,255,255,0.08);
+      border: 0.5pt solid rgba(255,255,255,0.15);
+      border-radius: 6px;
+      padding: 6mm;
+      backdrop-filter: blur(2px);
+    }
+    .badge h4 {
+      margin: 0 0 2mm 0;
+      font-size: 11pt;
+      color: #a7f3d0;
+    }
+    .badge p {
+      margin: 0;
+      font-size: 9pt;
+      color: #e5e7eb;
+    }
+
+    .cta {
+      position: absolute;
+      left: calc(var(--safe));
+      right: calc(var(--safe));
+      bottom: calc(var(--safe));
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 4mm;
+      align-items: end;
+      color: #fff;
+    }
+    .cta .phone {
+      font-size: 16pt;
+      font-weight: 800;
+      color: #a7f3d0;
+    }
+    .cta .btn {
+      justify-self: end;
+      background: #22c55e;
+      color: #06210e;
+      font-weight: 800;
+      padding: 4mm 7mm;
+      border-radius: 999px;
+      border: none;
+      font-size: 11pt;
+    }
+
+    /* Habillage verso */
+    .back {
+      background: #ffffff;
+      color: var(--text);
+    }
+    .back .header {
+      background: linear-gradient(90deg, #0f172a 0%, #0b2534 60%, #0a3f39 100%);
+      color: #fff;
+      padding: 10mm var(--safe);
+      position: absolute;
+      left: var(--bleed);
+      right: var(--bleed);
+      top: var(--bleed);
+    }
+    .back .header h2 {
+      margin: 0;
+      font-size: 16pt;
+      font-weight: 800;
+    }
+    .back .content {
+      position: absolute;
+      left: calc(var(--bleed) + var(--safe));
+      right: calc(var(--bleed) + var(--safe));
+      top: calc(var(--bleed) + 28mm);
+      bottom: calc(var(--bleed) + 36mm);
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8mm;
+      font-size: 10pt;
+      line-height: 1.45;
+    }
+    .card {
+      border: 0.5pt solid #e5e7eb;
+      border-radius: 8px;
+      padding: 6mm;
+    }
+    .card h3 {
+      margin: 0 0 3mm 0;
+      font-size: 12pt;
+      color: #0f172a;
+    }
+    .list {
+      margin: 0;
+      padding: 0 0 0 4mm;
+    }
+    .list li {
+      margin: 1.2mm 0;
+    }
+    .highlight {
+      background: #f0fdf4;
+      border: 0.5pt solid #bbf7d0;
+      color: #065f46;
+      padding: 3mm 4mm;
+      border-radius: 6px;
+      font-weight: 700;
+    }
+    .legal {
+      position: absolute;
+      left: calc(var(--bleed) + var(--safe));
+      right: calc(var(--bleed) + var(--safe));
+      bottom: calc(var(--bleed) + var(--safe));
+      font-size: 8pt;
+      color: var(--muted);
+      line-height: 1.35;
+    }
+
+    /* Print hints: enlever ombre et fond écran à l'impression */
+    @media print {
+      html, body { background: transparent; }
+      .page { box-shadow: none; margin: 0 auto; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- RECTO -->
+  <section class="page" aria-label="Recto">
+    <div class="artboard hero">
+      <!-- Traits de coupe -->
+      <div class="crop h top-left h"></div>
+      <div class="crop v top-left v"></div>
+      <div class="crop h top-right h"></div>
+      <div class="crop v top-right v"></div>
+      <div class="crop h bottom-left h"></div>
+      <div class="crop v bottom-left v"></div>
+      <div class="crop h bottom-right h"></div>
+      <div class="crop v bottom-right v"></div>
+
+      <div class="trim">
+        <div class="safe">
+          <div class="brand">
+            <div class="logo" aria-hidden="true"></div>
+            <div class="name">RCP Multiservices</div>
+          </div>
+
+          <div class="headline">
+            Services à domicile en Île‑de‑France
+            pour simplifier votre quotidien
+          </div>
+
+          <div class="sub">
+            Aide à domicile, ménage, jardinage, accompagnement. Personnel qualifié,
+            assuré et à l’écoute. Devis gratuit sous 24h.
+          </div>
+
+          <div class="badges">
+            <div class="badge">
+              <h4>Ménage & repassage</h4>
+              <p>Prestation soignée et régulière. Produits écologiques sur demande.</p>
+            </div>
+            <div class="badge">
+              <h4>Jardinage</h4>
+              <p>Tonte, taille, désherbage, remise en état. Intervention rapide.</p>
+            </div>
+            <div class="badge">
+              <h4>Aide à domicile</h4>
+              <p>Accompagnement quotidien, courses, préparation de repas.</p>
+            </div>
+            <div class="badge">
+              <h4>Petits travaux</h4>
+              <p>Montage, petits dépannages, manutention légère.</p>
+            </div>
+          </div>
+
+          <div class="cta">
+            <div>
+              <div>Devis gratuit • Sous 24h</div>
+              <div class="phone">01 23 45 67 89</div>
+            </div>
+            <button class="btn">Contactez‑nous</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- VERSO -->
+  <section class="page" aria-label="Verso">
+    <div class="artboard back">
+      <!-- Traits de coupe -->
+      <div class="crop h top-left h"></div>
+      <div class="crop v top-left v"></div>
+      <div class="crop h top-right h"></div>
+      <div class="crop v top-right v"></div>
+      <div class="crop h bottom-left h"></div>
+      <div class="crop v bottom-left v"></div>
+      <div class="crop h bottom-right h"></div>
+      <div class="crop v bottom-right v"></div>
+
+      <div class="trim">
+        <div class="header">
+          <h2>Nos services</h2>
+        </div>
+
+        <div class="content">
+          <div class="card">
+            <h3>Prestations</h3>
+            <ul class="list">
+              <li>Ménage, vitres, repassage</li>
+              <li>Jardinage et entretien des espaces verts</li>
+              <li>Courses et accompagnement</li>
+              <li>Préparation de repas, aide au quotidien</li>
+              <li>Petits travaux et manutention</li>
+            </ul>
+          </div>
+
+          <div class="card">
+            <h3>Engagements</h3>
+            <ul class="list">
+              <li>Personnel qualifié et assuré</li>
+              <li>Intervention rapide en Île‑de‑France</li>
+              <li>Devis clair et sans surprise</li>
+              <li>Matériel fourni si nécessaire</li>
+              <li>Suivi qualité après intervention</li>
+            </ul>
+          </div>
+
+          <div class="card">
+            <h3>Contact</h3>
+            <ul class="list">
+              <li>Téléphone: 01 23 45 67 89</li>
+              <li>Email: contact@rcp-multiservices.com</li>
+              <li>Site: www.rcp-multiservices.com</li>
+              <li>Adresse: 123 Av. de la République, 75011 Paris</li>
+            </ul>
+            <div class="highlight" style="margin-top:4mm;">
+              Jusqu’à 50% de crédit d’impôt sur les services à la personne
+              (selon l’article 199 sexdecies du CGI, sous conditions).
+            </div>
+          </div>
+
+          <div class="card">
+            <h3>Tarification</h3>
+            <ul class="list">
+              <li>Devis gratuit et personnalisé</li>
+              <li>Tarifs TTC, hors fournitures spécifiques</li>
+              <li>Aides et CESU acceptés (le cas échéant)</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="legal">
+          <strong>Mentions légales minimales pour un flyer</strong><br>
+          RCP Multiservices — Statut: [ex: SAS] — Capital social: [ex: 10 000 €]<br>
+          Siège social: 123 Avenue de la République, 75011 Paris — Tél: 01 23 45 67 89 — Email: contact@rcp-multiservices.com<br>
+          RCS: [Ville] [numéro RCS] — SIREN/SIRET: [XXXXXXXXX / XXXXXXXXXXXXX] — TVA intracom: [FR..] — Assurance RC Pro: [Assureur + n° police]<br>
+          Directeur de la publication: [Nom] — Hébergeur du site: [si mention du site, nom + adresse + téléphone]<br>
+          Données personnelles: les informations collectées via nos moyens de contact sont utilisées pour répondre à vos demandes et ne sont pas cédées à des tiers. Droit d’accès et de rectification: contact@rcp-multiservices.com.<br>
+          Photos non contractuelles. Offre non cumulable, valable sous conditions. Ne pas jeter sur la voie publique.
+        </div>
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/flyer-a5.html
+++ b/flyer-a5.html
@@ -53,9 +53,11 @@
       top: var(--bleed);
       width: var(--paper-w);
       height: var(--paper-h);
-      background: white;
+      background: transparent; /* transparent sur le recto pour laisser voir le dégradé */
       overflow: hidden;
     }
+    /* Sur le verso on garde un fond blanc propre */
+    .back .trim { background: white; }
     .safe {
       position: absolute;
       left: calc(var(--bleed) + var(--safe));

--- a/flyer-a5.html
+++ b/flyer-a5.html
@@ -2,36 +2,37 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8">
-  <title>RCP Multiservices — Flyer A5 (avec fond perdu et traits de coupe)</title>
+  <title>RCP Multiservices — Flyer A5 (charte personnalisable)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Personnalisation rapide de la charte: modifiez les variables ci-dessous -->
   <style>
-    /* Impression: 2 pages (recto/verso), format A5 avec fond perdu simulé (3 mm) et traits de coupe */
-    @page {
-      size: A5 portrait;
-      margin: 0; /* On gère le fond perdu et la zone de sécurité manuellement */
-    }
+    @page { size: A5 portrait; margin: 0; }
 
     :root{
+      /* Format / marges */
       --bleed: 3mm;          /* fond perdu */
-      --safe: 6mm;           /* marge intérieure de sécurité */
+      --safe: 6mm;           /* marge de sécurité intérieure */
       --paper-w: 148mm;
       --paper-h: 210mm;
-      --bg: #0f172a;         /* slate-900 */
-      --primary: #22c55e;    /* green-500 */
-      --accent: #14b8a6;     /* teal-500 */
-      --text: #0b1220;       /* near black */
-      --muted: #475569;      /* slate-500 */
+
+      /* CHARTE – remplacez par vos couleurs et police de marque */
+      --brand-font: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+      --brand-primary: #22c55e;   /* ex: vert primaire */
+      --brand-accent:  #14b8a6;   /* ex: accent secondaire */
+      --brand-bg-1:    #0f172a;   /* fond dégradé recto (foncé) */
+      --brand-bg-2:    #0b2534;   /* fond dégradé recto (milieu) */
+      --brand-bg-3:    #0a3f39;   /* fond dégradé recto (clair) */
+      --brand-ink:     #0b1220;   /* texte principal */
+      --brand-muted:   #475569;   /* texte secondaire */
+      --brand-cta-ink: #06210e;   /* couleur texte bouton */
     }
 
-    html, body {
-      background: #888; /* rendu écran */
-      height: 100%;
-    }
-
+    html, body { background: #888; height: 100%; }
     body {
       margin: 0;
-      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-      color: #111827;
+      font-family: var(--brand-font);
+      color: var(--brand-ink);
     }
 
     .page {
@@ -45,14 +46,7 @@
       page-break-after: always;
     }
 
-    /* Zone d'impression (inclut le fond perdu) */
-    .artboard {
-      position: absolute;
-      inset: 0;
-      background: white;
-    }
-
-    /* Zone utile (bord à bord A5 sans fond perdu) */
+    .artboard { position: absolute; inset: 0; background: white; }
     .trim {
       position: absolute;
       left: var(--bleed);
@@ -62,8 +56,6 @@
       background: white;
       overflow: hidden;
     }
-
-    /* Marge de sécurité (éviter texte proche du bord) */
     .safe {
       position: absolute;
       left: calc(var(--bleed) + var(--safe));
@@ -72,204 +64,107 @@
       bottom: calc(var(--bleed) + var(--safe));
     }
 
-    /* Traits de coupe (4 coins) */
-    .crop {
-      position: absolute;
-      pointer-events: none;
-    }
-    /* horizontaux top/bottom */
-    .crop.h {
-      width: 8mm;
-      height: 0;
-      border-top: 0.25pt solid #000;
-    }
-    .crop.v {
-      width: 0;
-      height: 8mm;
-      border-left: 0.25pt solid #000;
-    }
-    .crop.top-left.h    { left: var(--bleed);            top: 0;                    transform: translate(-8mm, 0); }
-    .crop.top-left.v    { left: 0;                       top: var(--bleed);          transform: translate(0, -8mm); }
-    .crop.top-right.h   { right: var(--bleed);           top: 0;                    }
-    .crop.top-right.v   { right: 0;                      top: var(--bleed);          transform: translate(0, -8mm); }
-    .crop.bottom-left.h { left: var(--bleed);            bottom: 0;                 transform: translate(-8mm, 0); }
-    .crop.bottom-left.v { left: 0;                       bottom: var(--bleed);       }
-    .crop.bottom-right.h{ right: var(--bleed);           bottom: 0;                 }
-    .crop.bottom-right.v{ right: 0;                      bottom: var(--bleed);       }
+    /* Traits de coupe */
+    .crop { position: absolute; pointer-events: none; }
+    .crop.h { width: 8mm; height: 0; border-top: 0.25pt solid #000; }
+    .crop.v { width: 0; height: 8mm; border-left: 0.25pt solid #000; }
+    .crop.top-left.h    { left: var(--bleed);  top: 0; transform: translate(-8mm, 0); }
+    .crop.top-left.v    { left: 0;             top: var(--bleed); transform: translate(0, -8mm); }
+    .crop.top-right.h   { right: var(--bleed); top: 0; }
+    .crop.top-right.v   { right: 0;            top: var(--bleed); transform: translate(0, -8mm); }
+    .crop.bottom-left.h { left: var(--bleed);  bottom: 0; transform: translate(-8mm, 0); }
+    .crop.bottom-left.v { left: 0;             bottom: var(--bleed); }
+    .crop.bottom-right.h{ right: var(--bleed); bottom: 0; }
+    .crop.bottom-right.v{ right: 0;            bottom: var(--bleed); }
 
-    /* Habillage recto */
+    /* RECTO */
     .hero {
+      position: absolute; inset: 0; color: #fff;
+      background: linear-gradient(135deg, var(--brand-bg-1) 0%, var(--brand-bg-2) 60%, var(--brand-bg-3) 100%);
+    }
+    .brand {
       position: absolute;
-      inset: 0;
-      background: linear-gradient(135deg, var(--bg) 0%, #0b2534 60%, #0a3f39 100%);
+      left: var(--safe); top: var(--safe);
+      display: flex; gap: 10px; align-items: center;
+      font-weight: 800; letter-spacing: 0.3px;
       color: #fff;
     }
-    .hero .brand {
-      position: absolute;
-      left: calc(var(--safe));
-      top: calc(var(--safe));
-      display: flex;
-      gap: 10px;
-      align-items: center;
-      font-weight: 800;
-      letter-spacing: 0.3px;
+    .logo-img {
+      width: 16mm; height: 16mm; object-fit: contain; object-position: left center;
+      background: #ffffff12; border-radius: 3mm; padding: 2mm;
     }
-    .hero .brand .logo {
-      width: 14mm;
-      height: 14mm;
-      border-radius: 4mm;
-      background: radial-gradient(circle at 30% 30%, var(--primary), var(--accent));
-      box-shadow: 0 4px 16px rgba(34,197,94,0.4), inset 0 0 40px rgba(255,255,255,0.15);
+    .brand .name { font-size: 16pt; line-height: 1; }
+    .headline {
+      position: absolute; left: var(--safe); right: var(--safe); top: 38mm;
+      font-size: 22pt; font-weight: 800; line-height: 1.1; text-wrap: balance;
     }
-    .hero .brand .name {
-      font-size: 16pt;
-      line-height: 1;
+    .sub {
+      position: absolute; left: var(--safe); right: var(--safe); top: 78mm;
+      font-size: 11pt; color: #e2e8f0; line-height: 1.5;
     }
-    .hero .headline {
-      position: absolute;
-      left: calc(var(--safe));
-      right: calc(var(--safe));
-      top: 38mm;
-      font-size: 22pt;
-      font-weight: 800;
-      line-height: 1.1;
-      text-wrap: balance;
-    }
-    .hero .sub {
-      position: absolute;
-      left: calc(var(--safe));
-      right: calc(var(--safe));
-      top: 78mm;
-      font-size: 11pt;
-      color: #e2e8f0;
-      line-height: 1.5;
-    }
-    .hero .badges {
-      position: absolute;
-      left: calc(var(--safe));
-      right: calc(var(--safe));
-      top: 112mm;
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 6mm 8mm;
+    .badges {
+      position: absolute; left: var(--safe); right: var(--safe); top: 112mm;
+      display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6mm 8mm;
     }
     .badge {
       background: rgba(255,255,255,0.08);
       border: 0.5pt solid rgba(255,255,255,0.15);
-      border-radius: 6px;
-      padding: 6mm;
-      backdrop-filter: blur(2px);
+      border-radius: 6px; padding: 6mm; backdrop-filter: blur(2px);
     }
-    .badge h4 {
-      margin: 0 0 2mm 0;
-      font-size: 11pt;
-      color: #a7f3d0;
-    }
-    .badge p {
-      margin: 0;
-      font-size: 9pt;
-      color: #e5e7eb;
-    }
+    .badge h4 { margin: 0 0 2mm 0; font-size: 11pt; color: #a7f3d0; }
+    .badge p  { margin: 0; font-size: 9pt; color: #e5e7eb; }
 
     .cta {
-      position: absolute;
-      left: calc(var(--safe));
-      right: calc(var(--safe));
-      bottom: calc(var(--safe));
-      display: grid;
-      grid-template-columns: 1fr auto;
-      gap: 4mm;
-      align-items: end;
-      color: #fff;
+      position: absolute; left: var(--safe); right: var(--safe); bottom: var(--safe);
+      display: grid; grid-template-columns: 1fr auto; gap: 4mm; align-items: end; color: #fff;
     }
-    .cta .phone {
-      font-size: 16pt;
-      font-weight: 800;
-      color: #a7f3d0;
-    }
-    .cta .btn {
-      justify-self: end;
-      background: #22c55e;
-      color: #06210e;
-      font-weight: 800;
-      padding: 4mm 7mm;
-      border-radius: 999px;
-      border: none;
-      font-size: 11pt;
+    .cta .phone { font-size: 16pt; font-weight: 800; color: #a7f3d0; }
+    .btn {
+      justify-self: end; background: var(--brand-primary); color: var(--brand-cta-ink);
+      font-weight: 800; padding: 4mm 7mm; border-radius: 999px; border: none; font-size: 11pt;
     }
 
-    /* Habillage verso */
-    .back {
-      background: #ffffff;
-      color: var(--text);
-    }
+    /* VERSO */
+    .back { background: #fff; color: var(--brand-ink); }
     .back .header {
-      background: linear-gradient(90deg, #0f172a 0%, #0b2534 60%, #0a3f39 100%);
-      color: #fff;
-      padding: 10mm var(--safe);
-      position: absolute;
-      left: var(--bleed);
-      right: var(--bleed);
-      top: var(--bleed);
+      background: linear-gradient(90deg, var(--brand-bg-1) 0%, var(--brand-bg-2) 60%, var(--brand-bg-3) 100%);
+      color: #fff; padding: 10mm var(--safe);
+      position: absolute; left: var(--bleed); right: var(--bleed); top: var(--bleed);
     }
-    .back .header h2 {
-      margin: 0;
-      font-size: 16pt;
-      font-weight: 800;
-    }
-    .back .content {
+    .back .header h2 { margin: 0; font-size: 16pt; font-weight: 800; }
+    .content {
       position: absolute;
       left: calc(var(--bleed) + var(--safe));
       right: calc(var(--bleed) + var(--safe));
       top: calc(var(--bleed) + 28mm);
       bottom: calc(var(--bleed) + 36mm);
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 8mm;
-      font-size: 10pt;
-      line-height: 1.45;
+      display: grid; grid-template-columns: 1fr 1fr; gap: 8mm;
+      font-size: 10pt; line-height: 1.45;
     }
-    .card {
-      border: 0.5pt solid #e5e7eb;
-      border-radius: 8px;
-      padding: 6mm;
-    }
-    .card h3 {
-      margin: 0 0 3mm 0;
-      font-size: 12pt;
-      color: #0f172a;
-    }
-    .list {
-      margin: 0;
-      padding: 0 0 0 4mm;
-    }
-    .list li {
-      margin: 1.2mm 0;
-    }
+    .card { border: 0.5pt solid #e5e7eb; border-radius: 8px; padding: 6mm; }
+    .card h3 { margin: 0 0 3mm 0; font-size: 12pt; color: #0f172a; }
+    .list { margin: 0; padding: 0 0 0 4mm; }
+    .list li { margin: 1.2mm 0; }
     .highlight {
-      background: #f0fdf4;
-      border: 0.5pt solid #bbf7d0;
-      color: #065f46;
-      padding: 3mm 4mm;
-      border-radius: 6px;
-      font-weight: 700;
+      background: #f0fdf4; border: 0.5pt solid #bbf7d0; color: #065f46;
+      padding: 3mm 4mm; border-radius: 6px; font-weight: 700;
     }
     .legal {
-      position: absolute;
-      left: calc(var(--bleed) + var(--safe));
-      right: calc(var(--bleed) + var(--safe));
-      bottom: calc(var(--bleed) + var(--safe));
-      font-size: 8pt;
-      color: var(--muted);
-      line-height: 1.35;
+      position: absolute; left: calc(var(--bleed) + var(--safe));
+      right: calc(var(--bleed) + var(--safe)); bottom: calc(var(--bleed) + var(--safe));
+      font-size: 8pt; color: var(--brand-muted); line-height: 1.35;
     }
 
-    /* Print hints: enlever ombre et fond écran à l'impression */
     @media print {
       html, body { background: transparent; }
       .page { box-shadow: none; margin: 0 auto; }
     }
   </style>
+
+  <!-- Optionnel: charger une police Google (remplacez Inter par votre police) -->
+  <!-- <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet"> -->
 </head>
 <body>
 
@@ -289,7 +184,8 @@
       <div class="trim">
         <div class="safe">
           <div class="brand">
-            <div class="logo" aria-hidden="true"></div>
+            <!-- Remplacez src par le chemin de votre logo (PNG/SVG recommandé) -->
+            <img class="logo-img" src="assets/logo-placeholder.png" alt="Logo RCP Multiservices">
             <div class="name">RCP Multiservices</div>
           </div>
 

--- a/flyers/flyer-a5-1page.html
+++ b/flyers/flyer-a5-1page.html
@@ -5,10 +5,27 @@
   <title>RCP Multiservices — Flyer A5 (1 page)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="stylesheet" href="./theme.css">
   <style>
     /* Gabarit impression */
     @page { size: A5 portrait; margin: 0; }
+
+    /* Palette intégrée (assortie au site, vert/bleu profond) */
+    :root{
+      --bleed: 3mm;
+      --safe: 6mm;
+      --paper-w: 148mm;
+      --paper-h: 210mm;
+
+      --brand-font: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+      --brand-bg-1: #0c1b2a;   /* bleu nuit */
+      --brand-bg-2: #0b2740;   /* bleu pétrole */
+      --brand-bg-3: #0d3b66;   /* bleu profond */
+      --brand-primary: #16a34a;/* vert bouton */
+      --brand-accent:  #10b981;/* vert émeraude */
+      --ink: #0f172a;          /* texte principal */
+      --muted: #475569;        /* texte secondaire */
+      --cta-ink: #052e1c;      /* texte bouton */
+    }
 
     html, body { background: #f3f4f6; height: 100%; }
     body { margin: 0; font-family: var(--brand-font); color: var(--ink); }

--- a/flyers/flyer-a5-1page.html
+++ b/flyers/flyer-a5-1page.html
@@ -9,7 +9,7 @@
     /* Gabarit impression */
     @page { size: A5 portrait; margin: 0; }
 
-    /* Palette intégrée (assortie au site, vert/bleu profond) */
+    /* Palette intégrée (deux bleus) */
     :root{
       --bleed: 3mm;
       --safe: 6mm;
@@ -17,14 +17,16 @@
       --paper-h: 210mm;
 
       --brand-font: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-      --brand-bg-1: #0c1b2a;   /* bleu nuit */
-      --brand-bg-2: #0b2740;   /* bleu pétrole */
-      --brand-bg-3: #0d3b66;   /* bleu profond */
-      --brand-primary: #16a34a;/* vert bouton */
-      --brand-accent:  #10b981;/* vert émeraude */
+      /* Dégradé bleu -> plus lumineux */
+      --brand-bg-1: #1e3a8a;   /* blue-900 */
+      --brand-bg-2: #1d4ed8;   /* blue-700 */
+      --brand-bg-3: #3b82f6;   /* blue-500 */
+      /* CTA en bleu pour rester dans la même gamme */
+      --brand-primary: #2563eb;/* blue-600 */
+      --brand-accent:  #60a5fa;/* blue-400 */
       --ink: #0f172a;          /* texte principal */
       --muted: #475569;        /* texte secondaire */
-      --cta-ink: #052e1c;      /* texte bouton */
+      --cta-ink: #ffffff;      /* texte bouton (contraste sur bleu) */
     }
 
     html, body { background: #f3f4f6; height: 100%; }

--- a/flyers/flyer-a5-1page.html
+++ b/flyers/flyer-a5-1page.html
@@ -5,28 +5,10 @@
   <title>RCP Multiservices — Flyer A5 (1 page)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
+  <link rel="stylesheet" href="./theme.css">
   <style>
     /* Gabarit impression */
     @page { size: A5 portrait; margin: 0; }
-
-    :root{
-      /* Fond perdu / marges */
-      --bleed: 3mm;
-      --safe: 6mm;
-      --paper-w: 148mm;
-      --paper-h: 210mm;
-
-      /* Palette inspirée du site (en attendant vos codes exacts) */
-      --brand-font: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-      --brand-bg-1: #0f172a;    /* bleu nuit */
-      --brand-bg-2: #0b2534;    /* bleu pétrole */
-      --brand-bg-3: #0a3f39;    /* vert foncé */
-      --brand-primary: #22c55e; /* bouton / cta */
-      --brand-accent: #14b8a6;  /* accent */
-      --ink: #0b1220;           /* texte courant */
-      --muted: #475569;         /* texte secondaire */
-      --cta-ink: #06210e;       /* texte bouton */
-    }
 
     html, body { background: #f3f4f6; height: 100%; }
     body { margin: 0; font-family: var(--brand-font); color: var(--ink); }

--- a/flyers/flyer-a5-1page.html
+++ b/flyers/flyer-a5-1page.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>RCP Multiservices — Flyer A5 (1 page)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <style>
+    /* Gabarit impression */
+    @page { size: A5 portrait; margin: 0; }
+
+    :root{
+      /* Fond perdu / marges */
+      --bleed: 3mm;
+      --safe: 6mm;
+      --paper-w: 148mm;
+      --paper-h: 210mm;
+
+      /* Palette inspirée du site (en attendant vos codes exacts) */
+      --brand-font: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+      --brand-bg-1: #0f172a;    /* bleu nuit */
+      --brand-bg-2: #0b2534;    /* bleu pétrole */
+      --brand-bg-3: #0a3f39;    /* vert foncé */
+      --brand-primary: #22c55e; /* bouton / cta */
+      --brand-accent: #14b8a6;  /* accent */
+      --ink: #0b1220;           /* texte courant */
+      --muted: #475569;         /* texte secondaire */
+      --cta-ink: #06210e;       /* texte bouton */
+    }
+
+    html, body { background: #f3f4f6; height: 100%; }
+    body { margin: 0; font-family: var(--brand-font); color: var(--ink); }
+
+    .page {
+      position: relative;
+      width: calc(var(--paper-w) + var(--bleed) * 2);
+      height: calc(var(--paper-h) + var(--bleed) * 2);
+      margin: 12px auto;
+      background: #fff;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.12);
+      overflow: hidden;
+    }
+
+    .artboard { position: absolute; inset: 0; }
+    .trim {
+      position: absolute;
+      left: var(--bleed); top: var(--bleed);
+      width: var(--paper-w); height: var(--paper-h);
+      background: #fff;
+      overflow: hidden;
+    }
+    .safe {
+      position: absolute;
+      inset: calc(var(--safe));
+    }
+
+    /* Traits de coupe */
+    .crop { position: absolute; pointer-events: none; }
+    .crop.h { width: 8mm; height: 0; border-top: 0.25pt solid #000; }
+    .crop.v { width: 0; height: 8mm; border-left: 0.25pt solid #000; }
+    .crop.top-left.h    { left: var(--bleed);  top: 0; transform: translate(-8mm, 0); }
+    .crop.top-left.v    { left: 0;             top: var(--bleed); transform: translate(0, -8mm); }
+    .crop.top-right.h   { right: var(--bleed); top: 0; }
+    .crop.top-right.v   { right: 0;            top: var(--bleed); transform: translate(0, -8mm); }
+    .crop.bottom-left.h { left: var(--bleed);  bottom: 0; transform: translate(-8mm, 0); }
+    .crop.bottom-left.v { left: 0;             bottom: var(--bleed); }
+    .crop.bottom-right.h{ right: var(--bleed); bottom: 0; }
+    .crop.bottom-right.v{ right: 0;            bottom: var(--bleed); }
+
+    /* Mise en page sans superposition (flow layout) */
+    .container {
+      display: flex;
+      flex-direction: column;
+      gap: 6mm;
+      height: 100%;
+    }
+
+    .hero {
+      background: linear-gradient(135deg, var(--brand-bg-1) 0%, var(--brand-bg-2) 60%, var(--brand-bg-3) 100%);
+      color: #fff;
+      border-radius: 8px;
+      padding: 8mm;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 6mm;
+      align-items: center;
+    }
+    .logo {
+      width: 18mm; height: 18mm; object-fit: contain; object-position: left center;
+      background: #ffffff12; border-radius: 3mm; padding: 2mm;
+    }
+    .brand {
+      display: flex; flex-direction: column; gap: 2mm;
+    }
+    .brand h1 { margin: 0; font-size: 18pt; line-height: 1; }
+    .brand p  { margin: 0; color: #e2e8f0; font-size: 10pt; }
+
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 5mm;
+      flex: 1;
+    }
+    .card {
+      border: 0.5pt solid #e5e7eb;
+      border-radius: 8px;
+      padding: 5mm;
+    }
+    .card h3 { margin: 0 0 2mm 0; font-size: 12pt; color: #0f172a; }
+    .list { margin: 0; padding-left: 4mm; font-size: 10pt; }
+    .list li { margin: 1mm 0; }
+
+    .highlight {
+      background: #f0fdf4; border: 0.5pt solid #bbf7d0; color: #065f46;
+      padding: 3mm 4mm; border-radius: 6px; font-weight: 700; font-size: 10pt;
+    }
+
+    .cta {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 4mm;
+      align-items: center;
+      padding: 5mm;
+      border-radius: 8px;
+      background: #f8fafc;
+      border: 0.5pt solid #e5e7eb;
+    }
+    .cta .phone { font-size: 16pt; font-weight: 800; color: var(--brand-bg-3); }
+    .btn {
+      background: var(--brand-primary);
+      color: var(--cta-ink);
+      font-weight: 800;
+      padding: 4mm 7mm;
+      border-radius: 999px;
+      border: none;
+      font-size: 11pt;
+    }
+
+    .legal {
+      margin-top: auto;
+      font-size: 8pt;
+      color: var(--muted);
+      line-height: 1.35;
+    }
+
+    @media print {
+      html, body { background: transparent; }
+      .page { box-shadow: none; margin: 0 auto; }
+    }
+  </style>
+</head>
+<body>
+  <section class="page" aria-label="Flyer A5 1 page">
+    <div class="artboard">
+      <!-- Traits de coupe -->
+      <div class="crop h top-left h"></div>
+      <div class="crop v top-left v"></div>
+      <div class="crop h top-right h"></div>
+      <div class="crop v top-right v"></div>
+      <div class="crop h bottom-left h"></div>
+      <div class="crop v bottom-left v"></div>
+      <div class="crop h bottom-right h"></div>
+      <div class="crop v bottom-right v"></div>
+
+      <div class="trim">
+        <div class="safe">
+          <div class="container">
+            <div class="hero">
+              <img class="logo" src="/assets/logo-placeholder.png" alt="Logo">
+              <div class="brand">
+                <h1>RCP Multiservices</h1>
+                <p>Services à domicile en Île‑de‑France · aide · ménage · jardinage</p>
+              </div>
+            </div>
+
+            <div class="grid">
+              <div class="card">
+                <h3>Prestations</h3>
+                <ul class="list">
+                  <li>Ménage, vitres, repassage</li>
+                  <li>Jardinage et entretien</li>
+                  <li>Courses et accompagnement</li>
+                  <li>Préparation de repas</li>
+                  <li>Petits travaux</li>
+                </ul>
+              </div>
+              <div class="card">
+                <h3>Engagements</h3>
+                <ul class="list">
+                  <li>Personnel qualifié et assuré</li>
+                  <li>Intervention rapide en Île‑de‑France</li>
+                  <li>Devis clair et sans surprise</li>
+                  <li>Matériel fourni si nécessaire</li>
+                  <li>Suivi qualité après intervention</li>
+                </ul>
+              </div>
+            </div>
+
+            <div class="highlight">
+              Jusqu’à 50% de crédit d’impôt sur les services à la personne
+              (article 199 sexdecies du CGI, sous conditions).
+            </div>
+
+            <div class="cta">
+              <div>
+                Devis gratuit sous 24h<br>
+                <span class="phone">01 23 45 67 89</span>
+              </div>
+              <button class="btn">Contactez‑nous</button>
+            </div>
+
+            <div class="legal">
+              RCP Multiservices — Statut: [SAS] — Capital: [10 000 €] · SIREN/SIRET: [XXXXXXXXX / XXXXXXXXXXXXX] ·
+              RCS: [Ville] [n°] · TVA intracom: [FR..] · RC Pro: [Assureur + n° police] ·
+              Siège: 123 Av. de la République, 75011 Paris — Tél: 01 23 45 67 89 — contact@rcp-multiservices.com ·
+              Directeur de la publication: [Nom] · Ne pas jeter sur la voie publique.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/flyers/flyer-a5-2pages.html
+++ b/flyers/flyer-a5-2pages.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>RCP Multiservices — Flyer A5 (2 pages)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <style>
+    @page { size: A5 portrait; margin: 0; }
+
+    :root{
+      --bleed: 3mm;
+      --safe: 6mm;
+      --paper-w: 148mm;
+      --paper-h: 210mm;
+
+      /* Palette assortie au site (ajustable) */
+      --brand-font: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+      --brand-bg-1: #0f172a;
+      --brand-bg-2: #0b2534;
+      --brand-bg-3: #0a3f39;
+      --brand-primary: #22c55e;
+      --brand-accent: #14b8a6;
+      --ink: #0b1220;
+      --muted: #475569;
+      --cta-ink: #06210e;
+    }
+
+    html, body { background: #f3f4f6; height: 100%; }
+    body { margin: 0; font-family: var(--brand-font); color: var(--ink); }
+
+    .page {
+      position: relative;
+      width: calc(var(--paper-w) + var(--bleed) * 2);
+      height: calc(var(--paper-h) + var(--bleed) * 2);
+      margin: 12px auto;
+      background: #fff;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.12);
+      overflow: hidden;
+      page-break-after: always;
+    }
+
+    .artboard { position: absolute; inset: 0; }
+    .trim { position: absolute; left: var(--bleed); top: var(--bleed); width: var(--paper-w); height: var(--paper-h); background: #fff; overflow: hidden; }
+    .safe { position: absolute; inset: var(--safe); }
+
+    /* Traits de coupe */
+    .crop { position: absolute; pointer-events: none; }
+    .crop.h { width: 8mm; height: 0; border-top: 0.25pt solid #000; }
+    .crop.v { width: 0; height: 8mm; border-left: 0.25pt solid #000; }
+    .crop.top-left.h    { left: var(--bleed);  top: 0; transform: translate(-8mm, 0); }
+    .crop.top-left.v    { left: 0;             top: var(--bleed); transform: translate(0, -8mm); }
+    .crop.top-right.h   { right: var(--bleed); top: 0; }
+    .crop.top-right.v   { right: 0;            top: var(--bleed); transform: translate(0, -8mm); }
+    .crop.bottom-left.h { left: var(--bleed);  bottom: 0; transform: translate(-8mm, 0); }
+    .crop.bottom-left.v { left: 0;             bottom: var(--bleed); }
+    .crop.bottom-right.h{ right: var(--bleed); bottom: 0; }
+    .crop.bottom-right.v{ right: 0;            bottom: var(--bleed); }
+
+    /* Styles communs */
+    .hero {
+      background: linear-gradient(135deg, var(--brand-bg-1) 0%, var(--brand-bg-2) 60%, var(--brand-bg-3) 100%);
+      color: #fff; border-radius: 8px; padding: 8mm;
+      display: grid; grid-template-columns: auto 1fr; gap: 6mm; align-items: center;
+    }
+    .logo { width: 18mm; height: 18mm; object-fit: contain; background: #ffffff12; border-radius: 3mm; padding: 2mm; }
+    h1 { margin: 0; font-size: 18pt; line-height: 1; }
+    .tag { margin: 0; color: #e2e8f0; font-size: 10pt; }
+
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 5mm; }
+    .card { border: 0.5pt solid #e5e7eb; border-radius: 8px; padding: 5mm; }
+    .card h3 { margin: 0 0 2mm 0; font-size: 12pt; color: #0f172a; }
+    .list { margin: 0; padding-left: 4mm; font-size: 10pt; }
+    .list li { margin: 1mm 0; }
+
+    .cta {
+      display: grid; grid-template-columns: 1fr auto; gap: 4mm; align-items: center;
+      padding: 5mm; border-radius: 8px; background: #f8fafc; border: 0.5pt solid #e5e7eb;
+    }
+    .cta .phone { font-size: 16pt; font-weight: 800; color: var(--brand-bg-3); }
+    .btn { background: var(--brand-primary); color: var(--cta-ink); font-weight: 800; padding: 4mm 7mm; border-radius: 999px; border: none; font-size: 11pt; }
+
+    .legal { font-size: 8pt; color: var(--muted); line-height: 1.35; }
+
+    @media print {
+      html, body { background: transparent; }
+      .page { box-shadow: none; margin: 0 auto; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Page 1: image de marque + promesse + services clés -->
+  <section class="page" aria-label="Recto">
+    <div class="artboard">
+      <!-- Traits de coupe -->
+      <div class="crop h top-left h"></div>
+      <div class="crop v top-left v"></div>
+      <div class="crop h top-right h"></div>
+      <div class="crop v top-right v"></div>
+      <div class="crop h bottom-left h"></div>
+      <div class="crop v bottom-left v"></div>
+      <div class="crop h bottom-right h"></div>
+      <div class="crop v bottom-right v"></div>
+
+      <div class="trim">
+        <div class="safe" style="display:flex;flex-direction:column;gap:6mm;height:100%;">
+          <div class="hero">
+            <img class="logo" src="/assets/logo-placeholder.png" alt="Logo">
+            <div>
+              <h1>RCP Multiservices</h1>
+              <p class="tag">Services à domicile en Île‑de‑France · aide · ménage · jardinage</p>
+            </div>
+          </div>
+
+          <div class="grid" style="flex:1;">
+            <div class="card">
+              <h3>Prestations</h3>
+              <ul class="list">
+                <li>Ménage, vitres, repassage</li>
+                <li>Jardinage et entretien</li>
+                <li>Courses et accompagnement</li>
+                <li>Préparation de repas</li>
+                <li>Petits travaux</li>
+              </ul>
+            </div>
+            <div class="card">
+              <h3>Engagements</h3>
+              <ul class="list">
+                <li>Personnel qualifié et assuré</li>
+                <li>Intervention rapide en Île‑de‑France</li>
+                <li>Devis clair et sans surprise</li>
+                <li>Matériel fourni si nécessaire</li>
+                <li>Suivi qualité après intervention</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="cta">
+            <div>
+              Devis gratuit sous 24h<br>
+              <span class="phone">01 23 45 67 89</span>
+            </div>
+            <button class="btn">Contactez‑nous</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Page 2: détails + mentions légales -->
+  <section class="page" aria-label="Verso">
+    <div class="artboard">
+      <!-- Traits de coupe -->
+      <div class="crop h top-left h"></div>
+      <div class="crop v top-left v"></div>
+      <div class="crop h top-right h"></div>
+      <div class="crop v top-right v"></div>
+      <div class="crop h bottom-left h"></div>
+      <div class="crop v bottom-left v"></div>
+      <div class="crop h bottom-right h"></div>
+      <div class="crop v bottom-right v"></div>
+
+      <div class="trim">
+        <div class="safe" style="display:flex;flex-direction:column;gap:6mm;height:100%;">
+          <div class="card" style="border-color:#dbeafe;background:#f8fafc;">
+            <h3 style="color:#0f172a;margin-top:0;">Détails des prestations</h3>
+            <ul class="list">
+              <li>Forfaits réguliers et prestations ponctuelles</li>
+              <li>Produits écologiques possibles</li>
+              <li>Interventions sur toute l’Île‑de‑France</li>
+              <li>Devis sous 24h, planification flexible</li>
+              <li>Facturation claire et suivi qualité</li>
+            </ul>
+          </div>
+
+          <div class="card">
+            <h3>Contact</h3>
+            <ul class="list">
+              <li>Téléphone: 01 23 45 67 89</li>
+              <li>Email: contact@rcp-multiservices.com</li>
+              <li>Site: www.rcp-multiservices.com</li>
+              <li>Adresse: 123 Av. de la République, 75011 Paris</li>
+            </ul>
+            <div style="margin-top:4mm;background:#f0fdf4;border:0.5pt solid #bbf7d0;color:#065f46;padding:3mm 4mm;border-radius:6px;font-weight:700;">
+              Jusqu’à 50% de crédit d’impôt (art. 199 sexdecies du CGI, sous conditions).
+            </div>
+          </div>
+
+          <div class="legal" style="margin-top:auto;">
+            RCP Multiservices — Statut: [SAS] — Capital: [10 000 €] · SIREN/SIRET: [XXXXXXXXX / XXXXXXXXXXXXX] ·
+            RCS: [Ville] [n°] · TVA intracom: [FR..] · RC Pro: [Assureur + n° police] ·
+            Siège: 123 Av. de la République, 75011 Paris — Tél: 01 23 45 67 89 — contact@rcp-multiservices.com ·
+            Directeur de la publication: [Nom] · Ne pas jeter sur la voie publique.
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/flyers/flyer-a5-2pages.html
+++ b/flyers/flyer-a5-2pages.html
@@ -5,9 +5,26 @@
   <title>RCP Multiservices — Flyer A5 (2 pages)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="stylesheet" href="./theme.css">
   <style>
     @page { size: A5 portrait; margin: 0; }
+
+    /* Palette intégrée (assortie au site, vert/bleu profond) */
+    :root{
+      --bleed: 3mm;
+      --safe: 6mm;
+      --paper-w: 148mm;
+      --paper-h: 210mm;
+
+      --brand-font: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+      --brand-bg-1: #0c1b2a;   /* bleu nuit */
+      --brand-bg-2: #0b2740;   /* bleu pétrole */
+      --brand-bg-3: #0d3b66;   /* bleu profond */
+      --brand-primary: #16a34a;/* vert bouton */
+      --brand-accent:  #10b981;/* vert émeraude */
+      --ink: #0f172a;          /* texte principal */
+      --muted: #475569;        /* texte secondaire */
+      --cta-ink: #052e1c;      /* texte bouton */
+    }
 
     html, body { background: #f3f4f6; height: 100%; }
     body { margin: 0; font-family: var(--brand-font); color: var(--ink); }

--- a/flyers/flyer-a5-2pages.html
+++ b/flyers/flyer-a5-2pages.html
@@ -5,26 +5,9 @@
   <title>RCP Multiservices — Flyer A5 (2 pages)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
+  <link rel="stylesheet" href="./theme.css">
   <style>
     @page { size: A5 portrait; margin: 0; }
-
-    :root{
-      --bleed: 3mm;
-      --safe: 6mm;
-      --paper-w: 148mm;
-      --paper-h: 210mm;
-
-      /* Palette assortie au site (ajustable) */
-      --brand-font: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-      --brand-bg-1: #0f172a;
-      --brand-bg-2: #0b2534;
-      --brand-bg-3: #0a3f39;
-      --brand-primary: #22c55e;
-      --brand-accent: #14b8a6;
-      --ink: #0b1220;
-      --muted: #475569;
-      --cta-ink: #06210e;
-    }
 
     html, body { background: #f3f4f6; height: 100%; }
     body { margin: 0; font-family: var(--brand-font); color: var(--ink); }

--- a/flyers/flyer-a5-2pages.html
+++ b/flyers/flyer-a5-2pages.html
@@ -8,7 +8,7 @@
   <style>
     @page { size: A5 portrait; margin: 0; }
 
-    /* Palette intégrée (assortie au site, vert/bleu profond) */
+    /* Palette intégrée (deux bleus) */
     :root{
       --bleed: 3mm;
       --safe: 6mm;
@@ -16,14 +16,16 @@
       --paper-h: 210mm;
 
       --brand-font: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-      --brand-bg-1: #0c1b2a;   /* bleu nuit */
-      --brand-bg-2: #0b2740;   /* bleu pétrole */
-      --brand-bg-3: #0d3b66;   /* bleu profond */
-      --brand-primary: #16a34a;/* vert bouton */
-      --brand-accent:  #10b981;/* vert émeraude */
+      /* Dégradé bleu -> plus lumineux */
+      --brand-bg-1: #1e3a8a;   /* blue-900 */
+      --brand-bg-2: #1d4ed8;   /* blue-700 */
+      --brand-bg-3: #3b82f6;   /* blue-500 */
+      /* CTA en bleu pour rester dans la même gamme */
+      --brand-primary: #2563eb;/* blue-600 */
+      --brand-accent:  #60a5fa;/* blue-400 */
       --ink: #0f172a;          /* texte principal */
       --muted: #475569;        /* texte secondaire */
-      --cta-ink: #052e1c;      /* texte bouton */
+      --cta-ink: #ffffff;      /* texte bouton (contraste sur bleu) */
     }
 
     html, body { background: #f3f4f6; height: 100%; }

--- a/flyers/theme.css
+++ b/flyers/theme.css
@@ -1,0 +1,30 @@
+:root{
+  /* Format / marges (ne changez pas sauf besoin) */
+  --bleed: 3mm;
+  --safe: 6mm;
+  --paper-w: 148mm;
+  --paper-h: 210mm;
+
+  /* PALETTE MARQUE - A REMPLACER PAR LES COULEURS DU SITE */
+  /* Indiquez-moi vos codes pour que je les verrouille ici */
+  --brand-font: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+
+  /* Exemple actuel (provisoire) */
+  --brand-bg-1: #111827;   /* fond 1 */
+  --brand-bg-2: #0b2534;   /* fond 2 */
+  --brand-bg-3: #0a3f39;   /* fond 3 */
+  --brand-primary: #16a34a;/* CTA */
+  --brand-accent:  #0891b2;/* accent */
+  --ink: #0b1220;          /* texte principal */
+  --muted: #475569;        /* texte secondaire */
+  --cta-ink: #06210e;      /* texte bouton */
+}
+
+/* Variante claire (si besoin) */
+/*
+:root{
+  --brand-bg-1:#0c1b2a; --brand-bg-2:#0b2740; --brand-bg-3:#0d3b66;
+  --brand-primary:#2dd4bf; --brand-accent:#60a5fa;
+  --ink:#0b1220; --muted:#475569; --cta-ink:#06210e;
+}
+*/


### PR DESCRIPTION
Ajout du fichier flyer-a5.html qui génère un flyer A5 prêt à imprimer en recto/verso, avec fond perdu simulé et traits de coupe.

Ce fichier contient:
- une mise en page A5 portrait et un fond perdu de 3 mm, géré via des variables CSS et une zone utile (trim) de 148 x 210 mm avec marge de sécurité de 6 mm.
- des traits de coupe visibles (crop marks) autour du périmètre pour faciliter l’impression et la coupe.
- une habillage recto/verso avec contenu d’exemple et un volet “Mentions légales minimales” sur le verso.
- des sections imprimables adaptées avec des règles CSS pour l’impression (pas d’ombres ni fond écran à l’impression).

Ce que cela résout:
- Fournit un flyer conçu pour l’impression en A5, en respectant les zones de coupe, le fond perdu et les marges de sécurité afin d’éviter que du texte soit tronqué.
- Intègre les mentions légales minimales directement dans le verso pour conformité et complétude.

Usage:
- Ouvrir flyer-a5.html dans un navigateur et imprimer; cela générera deux pages (recto et verso) avec les marges et zones de sécurité correctement positionnées, prêtes à être assemblées.

Notes:
- Le contenu texte est un exemple et peut être ajusté selon les besoins (nom de l’entreprise, coordonnées, prestations, etc.).

---

> This pull request was co-created with Cosine Genie

Original Task: [RCP-Multiservices/0qzk8ld4phpu](https://cosine.sh/nezjuvaeh4s3/RCP-Multiservices/task/0qzk8ld4phpu)
Author: Soofmax
